### PR TITLE
feat: add selector option, closes #25

### DIFF
--- a/lib/css-sets-formatter.js
+++ b/lib/css-sets-formatter.js
@@ -34,7 +34,9 @@ const formatter = ({ dictionary, platform, file, options }) => {
     );
   });
 
-  return `:root {
+  const selector = options.selector ?? ":root";
+
+  return `${selector} {
 ${resultAr.join(`
 `)}
 }

--- a/tests/css-formatter.test.js
+++ b/tests/css-formatter.test.js
@@ -122,3 +122,21 @@ test("prefix option should be added to var name", () => {
   });
   expect(result).toEqual(expected);
 });
+
+test("selector option should set rule selector", () => {
+  const filename = "multi-depth";
+  const config = generateConfig(filename);
+  config.platforms.CSS.files[0].options.selector = '.aselector';
+  const sd = StyleDictionary.extend(config);
+  sd.buildAllPlatforms();
+  const result = fs.readFileSync(
+    path.join(helpers.outputDir, `${filename}.css`),
+    {
+      encoding: "utf8",
+    }
+  );
+  const expected = fs.readFileSync(`./tests/expected/${filename}-selector.css`, {
+    encoding: "utf8",
+  });
+  expect(result).toEqual(expected);
+});

--- a/tests/expected/multi-depth-selector.css
+++ b/tests/expected/multi-depth-selector.css
@@ -1,0 +1,5 @@
+.aselector {
+  --accent-color-1000: var(--blue-1000);
+  --blue-1000: rgb(143, 202, 252);
+  --indigo-1000: rgb(188, 190, 255);
+}


### PR DESCRIPTION
This PR adds support for `options.selector`, including tests.