### PR TITLE
fix: correct CSS formatter token names when nested sets are used

### DIFF
--- a/lib/css-sets-formatter.js
+++ b/lib/css-sets-formatter.js
@@ -22,12 +22,17 @@ const formatter = ({ dictionary, platform, file, options }) => {
   dictionary.allTokens.forEach((token) => {
     let name = platform.prefix ? [platform.prefix] : [];
     if (isASet(options)) {
-      const setsIndex = token.path.indexOf("sets");
-      name = name.concat(
-        token.path.filter((element, index) => {
-          return !(index == setsIndex || index == setsIndex + 1);
-        })
-      );
+      const cleanTokenPath = [];
+      for (let i = 0; i < token.path.length; i++) {
+        if (token.path[i] === "sets") {
+          i++;
+        }
+        else {
+          cleanTokenPath.push(token.path[i]);
+        }
+      }
+
+      name = name.concat(cleanTokenPath);
     }
     else {
       name = name.concat(token.path);

--- a/tests/css-formatter.test.js
+++ b/tests/css-formatter.test.js
@@ -28,7 +28,7 @@ const generateConfig = (filename) => {
                 !Array.isArray(token.attributes) &&
                 token.attributes !== null &&
                 "sets" in token.attributes &&
-                token.attributes.sets.some((element) => {
+                token.attributes.sets.every((element) => {
                   return ["desktop", "spectrum", "dark"].includes(element);
                 })
               );
@@ -71,6 +71,22 @@ test("basic data with sets keyword in path should provide basic css", () => {
 
 test("should handle multi nested reference css", () => {
   const filename = "multi-depth";
+  const sd = StyleDictionary.extend(generateConfig(filename));
+  sd.buildAllPlatforms();
+  const result = fs.readFileSync(
+    path.join(helpers.outputDir, `${filename}.css`),
+    {
+      encoding: "utf8",
+    }
+  );
+  const expected = fs.readFileSync(`./tests/expected/${filename}.css`, {
+    encoding: "utf8",
+  });
+  expect(result).toEqual(expected);
+});
+
+test("should work with nested sets", () => {
+  const filename = "nest-sets-no-refs";
   const sd = StyleDictionary.extend(generateConfig(filename));
   sd.buildAllPlatforms();
   const result = fs.readFileSync(

--- a/tests/expected/nest-sets-no-refs.css
+++ b/tests/expected/nest-sets-no-refs.css
@@ -1,0 +1,3 @@
+:root {
+  --component-size: 12px;
+}

--- a/tests/expected/nest-sets-no-refs.json
+++ b/tests/expected/nest-sets-no-refs.json
@@ -2,7 +2,7 @@
   "component": {
     "size": {
       "sets": {
-        "subSystemOne": {
+        "spectrum": {
           "sets": {
             "mobile": {
               "value": "15px",
@@ -11,15 +11,15 @@
               "original": {
                 "value": "15px"
               },
-              "name": "component-size-sets-sub-system-one-sets-mobile",
+              "name": "component-size-sets-spectrum-sets-mobile",
               "attributes": {
-                "sets": ["subSystemOne", "mobile"]
+                "sets": ["spectrum", "mobile"]
               },
               "path": [
                 "component",
                 "size",
                 "sets",
-                "subSystemOne",
+                "spectrum",
                 "sets",
                 "mobile"
               ]
@@ -31,22 +31,22 @@
               "original": {
                 "value": "12px"
               },
-              "name": "component-size-sets-sub-system-one-sets-desktop",
+              "name": "component-size-sets-spectrum-sets-desktop",
               "attributes": {
-                "sets": ["subSystemOne", "desktop"]
+                "sets": ["spectrum", "desktop"]
               },
               "path": [
                 "component",
                 "size",
                 "sets",
-                "subSystemOne",
+                "spectrum",
                 "sets",
                 "desktop"
               ]
             }
           }
         },
-        "subSystemTwo": {
+        "express": {
           "sets": {
             "mobile": {
               "value": "16px",
@@ -55,15 +55,15 @@
               "original": {
                 "value": "16px"
               },
-              "name": "component-size-sets-sub-system-two-sets-mobile",
+              "name": "component-size-sets-express-sets-mobile",
               "attributes": {
-                "sets": ["subSystemTwo", "mobile"]
+                "sets": ["express", "mobile"]
               },
               "path": [
                 "component",
                 "size",
                 "sets",
-                "subSystemTwo",
+                "express",
                 "sets",
                 "mobile"
               ]
@@ -75,15 +75,15 @@
               "original": {
                 "value": "13px"
               },
-              "name": "component-size-sets-sub-system-two-sets-desktop",
+              "name": "component-size-sets-express-sets-desktop",
               "attributes": {
-                "sets": ["subSystemTwo", "desktop"]
+                "sets": ["express", "desktop"]
               },
               "path": [
                 "component",
                 "size",
                 "sets",
-                "subSystemTwo",
+                "express",
                 "sets",
                 "desktop"
               ]

--- a/tests/fixtures/nest-sets-no-refs.json
+++ b/tests/fixtures/nest-sets-no-refs.json
@@ -2,7 +2,7 @@
   "component": {
     "size": {
       "sets": {
-        "subSystemOne": {
+        "spectrum": {
           "sets": {
             "mobile": {
               "value": "15px"
@@ -12,7 +12,7 @@
             }
           }
         },
-        "subSystemTwo": {
+        "express": {
           "sets": {
             "mobile": {
               "value": "16px"


### PR DESCRIPTION
Fixes #29

This changes one of the fixtures to use consistent system names.