### PR TITLE
fix: a build error in @adobe/spectrum-tokens

### DIFF
--- a/lib/css-sets-formatter.js
+++ b/lib/css-sets-formatter.js
@@ -19,7 +19,7 @@ const formatter = ({ dictionary, platform, file, options }) => {
     );
   });
 
-  const selector = options.selector ?? ":root";
+  const selector = options.selector ? options.selector : ":root";
 
   return `${selector} {
 ${resultAr.join(`


### PR DESCRIPTION
Not sure why, but the release from `@adobe/spectrum-tokens` was throwing this error:
```
stderr: 'npm ERR! code 1\n' +
    'npm ERR! path /home/runner/work/spectrum-tokens/spectrum-tokens\n' +
    'npm ERR! command failed\n' +
    'npm ERR! command sh -c husky install && yarn run build\n' +
    'npm ERR! husky - Git hooks installed\n' +
    'npm ERR! yarn run v1.22.19\n' +
    'npm ERR! $ style-dictionary build\n' +
    'npm ERR! info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.\n' +
    'npm ERR! /home/runner/work/spectrum-tokens/spectrum-tokens/node_modules/style-dictionary-sets/lib/css-sets-formatter.js:22\n' +
    'npm ERR!   const selector = options.selector ?? ":root";\n' +
    'npm ERR!                                      ^\n' +
    'npm ERR! \n' +
    "npm ERR! SyntaxError: Unexpected token '?'\n" +
```