### PR TITLE
Prep for Semantic Release plugin for Drover

### DIFF
--- a/lib/drover-json-formatter.js
+++ b/lib/drover-json-formatter.js
@@ -3,7 +3,7 @@ const helpers = require("./helper-functions.js");
 const initial = {
   drover: {
     system: "Spectrum",
-    version: "11.7.0",
+    version: "0.0.0-development",
     KEYS: {
       DIMENSION_LAYOUT_TOKENS: "layoutTokens",
       DIMENSION_COMPONENT_LAYOUT_TOKENS: "componentLayoutTokens",

--- a/tests/expected/drover-prefix.json
+++ b/tests/expected/drover-prefix.json
@@ -1,7 +1,7 @@
 {
   "drover": {
     "system": "Spectrum",
-    "version": "11.7.0",
+    "version": "0.0.0-development",
     "KEYS": {
       "DIMENSION_LAYOUT_TOKENS": "layoutTokens",
       "DIMENSION_COMPONENT_LAYOUT_TOKENS": "componentLayoutTokens",

--- a/tests/expected/drover.json
+++ b/tests/expected/drover.json
@@ -1,7 +1,7 @@
 {
   "drover": {
     "system": "Spectrum",
-    "version": "11.7.0",
+    "version": "0.0.0-development",
     "KEYS": {
       "DIMENSION_LAYOUT_TOKENS": "layoutTokens",
       "DIMENSION_COMPONENT_LAYOUT_TOKENS": "componentLayoutTokens",


### PR DESCRIPTION
Drover output should include a `version` field with the same version number as the `package.json` file. Semantic release can set this, but I changed the value to `0.0.0-development` to match the semantic release convention.