### PR TITLE
fix: drover parsing trouble with accent colors

### DIFF
--- a/lib/drover-json-formatter.js
+++ b/lib/drover-json-formatter.js
@@ -20,6 +20,8 @@ const initial = {
   dimensions: {},
 };
 
+const isExpress = (token) => token.name.indexOf('express') > -1;
+
 const genType = (token) => {
   if (!token.path.includes("express")) {
     if (helpers.colorRegex.test(token.value)) {
@@ -65,12 +67,7 @@ const getValue = (token, dictionary) => {
 const formatter = ({ dictionary, platform, file, options }) => {
   const prefix = platform.prefix ? platform.prefix : false;
   const result = { ...initial };
-  result.colorThemes = {
-    light: {},
-    dark: {},
-    darkest: {},
-  };
-  result.dimensions = {};
+
   dictionary.allTokens.forEach((token) => {
     if (dictionary.usesReference(token)) {
       if (
@@ -78,9 +75,18 @@ const formatter = ({ dictionary, platform, file, options }) => {
         token.value.sets.hasOwnProperty("spectrum") &&
         token.value.sets.hasOwnProperty("express")
       ) {
-        token.value = token.value.sets.spectrum;
+        // color alias with color semantic were getting tripped up here
+        // set the value here to just the value in spectrum
+        // instead of the whole token that comes in with the spectrum set
+        token.value = token.value.sets.spectrum.value;
+        // we might want to instead define a whole new token and save the 
+        // full ref, but drover doesn't care so this should be fine
       }
-      if (helpers.isASet(token.value)) {
+
+      // process sets here, but not a set that came from express
+      // the nested reference for accent-color gets stopped here
+      // could probably fix later in getValue but this works for now 
+      if (helpers.isASet(token.value) && !isExpress(token)) {
         const newValue = getValue(token, dictionary);
         if (
           newValue.sets.hasOwnProperty("light") &&
@@ -99,6 +105,8 @@ const formatter = ({ dictionary, platform, file, options }) => {
         } else {
           // The only token here is android elevation
         }
+
+        // it wasn't a set or it's an express set  
       } else {
         if (genType(token) == "colorGlobal") {
           result.colorThemes.light[
@@ -112,6 +120,7 @@ const formatter = ({ dictionary, platform, file, options }) => {
           ] = token.value;
         }
       }
+      // token didn't have a reference  
     } else {
       token.attributes.tokenType = genType(token);
       switch (token.attributes.tokenType) {
@@ -145,6 +154,7 @@ const formatter = ({ dictionary, platform, file, options }) => {
       }
     }
   });
+
   result.colorThemes.light = helpers.sortObject(
     result.colorThemes.light
   );


### PR DESCRIPTION
- fixes express colors leaking into accent-color values
- fixes missing accent-* values from color-alias.json
- cleans up double init of result nodes